### PR TITLE
Support more than 100 packages

### DIFF
--- a/src/Services/NuGetPackagesService.cs
+++ b/src/Services/NuGetPackagesService.cs
@@ -28,7 +28,7 @@ public class NuGetPackagesService(NuGetApiService nuGetApiService)
 
     private async Task FetchPackagesDataAsync(ProgressTask task, List<Package> packages)
     {
-        var incrementBy = 100 / packages.Count;
+        var incrementBy = 100.0 / packages.Count;
 
         foreach (var package in packages)
         {


### PR DESCRIPTION
I'm using a Directory.Packages.props file, but this issue probably can be reproduced with "Fba" and "Project" modes, too.

When there are more than 100 package references in the Packages file, the incrementBy will be 0 and the PackCheck will freeze, never completes.

I can attach my Directory.Packages.props file if you need it, but you can reproduce the issue with any 101+ random packages.

Easy solution is to use double instead of an integer.

Btw: I don't undestand why is the FetchPackageDataAsync call at line 20 is in a while loop. The task shouls be finished when the FetchPackageDataAsync call completes.